### PR TITLE
Add support for jiamari-emoji and jitarazu-emoji

### DIFF
--- a/config.example.json.ls
+++ b/config.example.json.ls
@@ -1,5 +1,7 @@
 slack-token: 'xxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxx-xxxxxxxxxx'
 ikku-emoji: 'flower_playing_cards'
+jiamari-emoji: ''
+jitarazu-emoji: ''
 channels: <[]>
 max-jiamari: 1
 max-jitarazu: 0

--- a/index.ls
+++ b/index.ls
@@ -23,6 +23,18 @@ web-client = new Web-client config.slack-token
 
 rtm-client.on DISCONNECT, -> process.exit 1
 
+add_reaction = (emoji, message) ->
+  if message.file?
+    web-client.reactions.add emoji, {
+      file: message.file.id
+      file_comment: message.file.initial_comment.id
+    }
+  else
+    web-client.reactions.add emoji, {
+      message.channel
+      timestamp: message.ts
+    }
+
 message <- rtm-client.on MESSAGE
 text = message.file?.initial_comment?.comment or message.text
 return unless text?
@@ -59,15 +71,12 @@ jiamari = target-regions |> zip-with (-), regions |> map max 0 |> fold1 (+)
 
 return if jitarazu > config.max-jitarazu or jiamari > config.max-jiamari
 
-if message.file?
-  web-client.reactions.add config.ikku-emoji, {
-    file: message.file.id
-    file_comment: message.file.initial_comment.id
-  }
-else
-  web-client.reactions.add config.ikku-emoji, {
-    message.channel
-    timestamp: message.ts
-  }
+add_reaction config.ikku-emoji, message
+
+if jiamari > 0 and config.jiamari-emoji? and config.jiamari-emoji.length > 0
+  add_reaction config.jiamari-emoji, message
+
+if jitarazu > 0 and config.jitarazu-emoji? and config.jitarazu-emoji.length > 0
+  add_reaction config.jitarazu-emoji, message
 
 console.log "[#{Date!}] Found ikku: #{util.inspect message}"


### PR DESCRIPTION
Hi, I added support for jiamari-emoji and jitarazu-emoji, because I want to look the reactions like the below.

![bf1478b4f8bf7ca37d6ecfb723eacf9d](https://cloud.githubusercontent.com/assets/1025342/16730928/7afdf7aa-47b0-11e6-9fff-69428bd769f8.png)

Could you review it? Thanks.